### PR TITLE
Update mediasorter.py

### DIFF
--- a/mediasorter.py
+++ b/mediasorter.py
@@ -115,6 +115,9 @@ def sort_tv_file(config, srcpath, dstpath):
         # Remove SXXEYY from the word
         if re.search(r'[Ss][0-9]+[Ee][0-9]+', word):
             word = re.sub(r'[Ss][0-9]+[Ee][0-9]+', '', word)
+        # Only remove years that are in parentheses
+        if re.search(r'^\(([0-9]{4})\)$', word):
+            continue
         raw_series_title.append(word)
     search_series_title = ' '.join([x.lower() for x in raw_series_title])
     if search_series_title in config['search_overrides']:


### PR DESCRIPTION
Currently, TV series with the year in the title (e.g., (year)) are included in the search results, which is causing issues.
![image](https://github.com/user-attachments/assets/92133c38-2330-4743-acb1-43dc1a2d4165)


This pull request aims to resolve the issue by excluding the year in parentheses from the search criteria while still including other numerical values.
![image](https://github.com/user-attachments/assets/038b0d89-1592-4945-9048-7078de427bd5)
